### PR TITLE
 Filtered Available Trainers by Preferred Location instead of Current Location

### DIFF
--- a/force-app/main/default/aura/afAvailabilityListContainer/afAvailabilityListContainer.cmp
+++ b/force-app/main/default/aura/afAvailabilityListContainer/afAvailabilityListContainer.cmp
@@ -70,7 +70,7 @@
                         <div class="slds-col slds-size_1-of-5 slds-align_absolute-center"></div>
                         <div class="slds-col slds-size_1-of-5 slds-align_absolute-center"><h1>Name</h1></div>
                         <div class="slds-col slds-size_1-of-5 slds-align_absolute-center"><h1>Available</h1></div>
-                        <div class="slds-col slds-size_1-of-5 slds-align_absolute-center"><h1>Current Location</h1></div>
+                        <div class="slds-col slds-size_1-of-5 slds-align_absolute-center"><h1>Preferred Location</h1></div>
                         <div class="slds-col slds-size_1-of-5 slds-align_absolute-center"><h1>Experienced</h1></div>
                     </div>
                     <!-- iteration to grab said columns stated earlier for each trainer -->

--- a/force-app/main/default/aura/afTrainerAvailabilityListItem/afTrainerAvailabilityListItem.cmp
+++ b/force-app/main/default/aura/afTrainerAvailabilityListItem/afTrainerAvailabilityListItem.cmp
@@ -32,7 +32,7 @@
                 
             </div>
             <div class="slds-col slds-size_1-of-5 slds-align_absolute-center">
-                <lightning:outputField fieldName="CurrentLocation__c" variant="label-hidden"/><!--figure out how to set up the locations-->
+                <lightning:outputField fieldName="Preferred_Location__c" variant="label-hidden"/><!--figure out how to set up the locations-->
             </div>
             <div class="slds-col slds-size_1-of-5 slds-align_absolute-center">
                 <!-- change this to checkbox if the trainer has the skill selected in create batch-->

--- a/force-app/main/default/classes/afAvailListContainerApexController.cls
+++ b/force-app/main/default/classes/afAvailListContainerApexController.cls
@@ -100,14 +100,14 @@ public class afAvailListContainerApexController {
 			upcomingPTOsUsers.add(t.Trainer__c);
 		}
 
-        List<User> notAvail = [SELECT Id, name, CurrentLocation__c, Available__c, hasSkill__c
+        List<User> notAvail = [SELECT Id, name, Preferred_Location__c, Available__c, hasSkill__c
                                 FROM User 
                                 WHERE (Id IN :upcomingTrainingsUsers
                                 OR Id IN :upcomingPTOsUsers)
                                 AND Profile.Name = 'Trainer'
 								ORDER BY LastName];
 
-        List<User> Avail = [ SELECT Id, name, CurrentLocation__c, Available__c, hasSkill__c
+        List<User> Avail = [ SELECT Id, name, Preferred_Location__c, Available__c, hasSkill__c
                                 FROM User 
                                 WHERE Id NOT IN :upcomingTrainingsUsers
                                 AND Id NOT IN :upcomingPTOsUsers
@@ -149,14 +149,14 @@ public class afAvailListContainerApexController {
 			upcomingPTOsUsers.add(t.Trainer__c);
 		}
 		
-        List<User> notAvail = [SELECT Id, name, CurrentLocation__c, Available__c, hasSkill__c
+        List<User> notAvail = [SELECT Id, name, Preferred_Location__c, Available__c, hasSkill__c
                             FROM User 
                             WHERE (Id IN :upcomingTrainingsUsers
                             OR Id IN :upcomingPTOsUsers)
                            	AND Profile.Name = 'Trainer'
 							ORDER BY LastName];
 
-        List<User> Avail = [ SELECT Id, name, CurrentLocation__c, Available__c, hasSkill__c
+        List<User> Avail = [ SELECT Id, name, Preferred_Location__c, Available__c, hasSkill__c
                                 FROM User 
                                 WHERE Id NOT IN :upcomingTrainingsUsers
                                 AND Id NOT IN :upcomingPTOsUsers
@@ -197,7 +197,7 @@ public class afAvailListContainerApexController {
 		//Two Queries:
 		//		1. Query for all trainers that match the selected skill
 		//		2. Query for all trainers that do not match the selected skill
-		List<User> matchSkill = [SELECT Id, name, CurrentLocation__c
+		List<User> matchSkill = [SELECT Id, name, Preferred_Location__c
 									FROM User 
 									WHERE Id IN (SELECT Trainer__c
 													FROM Skill__c 
@@ -205,7 +205,7 @@ public class afAvailListContainerApexController {
                                 	AND Profile.Name = 'Trainer'
 									ORDER BY LastName];
 
-		List<User> noMatchingSkill = [SELECT Id, name, CurrentLocation__c
+		List<User> noMatchingSkill = [SELECT Id, name, Preferred_Location__c
 										FROM User 
 										WHERE Id NOT IN (SELECT Trainer__c
 															FROM Skill__c 
@@ -291,15 +291,15 @@ public class afAvailListContainerApexController {
 		//Two Queries:
 		//		1. Query for all trainers that match the selected location
 		//		2. Query for all trainers that do not match the selected location
-		List<User> atLocation = [SELECT Id, name, CurrentLocation__c
+		List<User> atLocation = [SELECT Id, name, Preferred_Location__c
 									FROM User 
-									WHERE CurrentLocation__c = :selectedLocation
+									WHERE Preferred_Location__c = :selectedLocation
                                 	AND Profile.Name = 'Trainer'
 									ORDER BY LastName];
 
-		List<User> notAtLocation = [SELECT Id, name, CurrentLocation__c
+		List<User> notAtLocation = [SELECT Id, name, Preferred_Location__c
 										FROM User 
-										WHERE CurrentLocation__c != :selectedLocation
+										WHERE Preferred_Location__c != :selectedLocation
                                    		AND Profile.Name = 'Trainer'
 										ORDER BY LastName];						
 		

--- a/force-app/main/default/classes/afAvailListContainerApexControllerTest.cls
+++ b/force-app/main/default/classes/afAvailListContainerApexControllerTest.cls
@@ -56,10 +56,10 @@ public class afAvailListContainerApexControllerTest {
 
         //Update trainers so four trainers are at each of the 13 locations
         for (Integer i = 0; i < 13; i++){
-            trainers.get(i).CurrentLocation__c = locations.get(i).OfficeName__c;
-            trainers.get(i + 13).CurrentLocation__c = locations.get(i).OfficeName__c;
-            trainers.get(i + 26).CurrentLocation__c = locations.get(i).OfficeName__c;
-            trainers.get(i + 39).CurrentLocation__c = locations.get(i).OfficeName__c;
+            trainers.get(i).Preferred_Location__c = locations.get(i).OfficeName__c;
+            trainers.get(i + 13).Preferred_Location__c = locations.get(i).OfficeName__c;
+            trainers.get(i + 26).Preferred_Location__c = locations.get(i).OfficeName__c;
+            trainers.get(i + 39).Preferred_Location__c = locations.get(i).OfficeName__c;
         }
         update trainers;
 

--- a/force-app/main/default/roles/CTO.role-meta.xml
+++ b/force-app/main/default/roles/CTO.role-meta.xml
@@ -7,3 +7,4 @@
     <opportunityAccessLevel>Edit</opportunityAccessLevel>
     <parentRole>CEO</parentRole>
 </Role>
+


### PR DESCRIPTION
*04/17/2019*
- Field: **Preferred Location** is currently a *Text(80)* type. 
- To filter by **Preferred Location**, we need to change the field type to *Picklist*. 
- To add picklist values to this field, we can use a global picklist **Training Locations** or add local values. (Global picklist is recommended) 
- In **Available Trainers** tab: *Current Location* is replaced with *Preferred Location*.
- In **afAvailListContainerApexController**: *CurrentLocation__c* is replaced with *Preferred_Location__c*.

*04/18/2019*
- In **afTrainerAvailabilityListItem**: Replaced Output field name from *CurrentLocation__c* to *Preferred_Location__c*.

*04/19/2019*
- In **afAvailListContainerApexControllerTest**: Replaced Trainers location from *CurrentLocation__c* to *Preferred_Location__c*.